### PR TITLE
Redirect to payment on error

### DIFF
--- a/eway/rapid/views.py
+++ b/eway/rapid/views.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.contrib import messages
 from django.db.models import get_model
 from django.utils.translation import ugettext_lazy as _
+from django.http import HttpResponseRedirect
+from django.core.urlresolvers import reverse
 
 from oscar.core.loading import get_class
 
@@ -96,3 +98,11 @@ class RapidResponseView(PaymentDetailsView):
 
         # Also record payment event
         self.add_payment_event(PURCHASE, total_incl_tax)
+
+    def render_to_response(self, context, **response_kwargs):
+        if 'error' in context:
+            return HttpResponseRedirect(reverse('checkout:payment-details'))
+        return super(RapidResponseView, self).render_to_response(
+            context,
+            **response_kwargs
+        )

--- a/tests/functional/checkout_tests.py
+++ b/tests/functional/checkout_tests.py
@@ -185,6 +185,11 @@ class TestARegisteredUser(WebTestCase):
 
         self.assertRedirects(page, reverse("checkout:payment-details"))
         self.assertEquals(Order.objects.count(), 0)
+        page = page.follow()
+        self.assertContains(
+            page,
+            'We experienced a problem while processing your payment'
+        )
 
 
 GET_ACCESS_CODE_RESPONSE = """{


### PR DESCRIPTION
Currently if an error is returned from eWay when attempting to take the final payment it tried to render RapidResponseView which fails as it isn't really designed to be rendered to screen.

This pull request ensure the error message is set, then redirects the user back to the payment details page.
